### PR TITLE
Opt parse

### DIFF
--- a/cabal-plan.cabal
+++ b/cabal-plan.cabal
@@ -55,6 +55,7 @@ executable cabal-plan
   -- dependencies which require version bounds
   build-depends: mtl            >= 2.2.1 && < 2.3
                , ansi-terminal  >= 0.6.2 && < 0.7
+               , optparse-applicative >= 0.13.0 && < 0.14
 
   ghc-options: -Wall
 

--- a/cabal-plan.cabal
+++ b/cabal-plan.cabal
@@ -1,5 +1,5 @@
 name:                cabal-plan
-version:             0.1.1.0
+version:             0.1.1.1
 synopsis:            Library and utiltity for processing cabal's plan.json file
 homepage:            https://github.com/hvr/cabal-plan
 license:             GPL-3

--- a/src-exe/cabal-plan.hs
+++ b/src-exe/cabal-plan.hs
@@ -8,6 +8,7 @@ import           Control.Monad.RWS.Strict
 import qualified Data.Graph               as G
 import           Data.Map                 (Map)
 import qualified Data.Map                 as M
+import           Data.Semigroup           ((<>))
 import           Data.Set                 (Set)
 import qualified Data.Set                 as S
 import qualified Data.Text                as T
@@ -15,6 +16,7 @@ import qualified Data.Text.IO             as T
 import qualified Data.Text.Lazy           as LT
 import qualified Data.Text.Lazy.Builder   as LT
 import qualified Data.Text.Lazy.IO        as LT
+import           Options.Applicative
 import           System.Console.ANSI
 import           System.Environment
 
@@ -32,6 +34,21 @@ main = do
       ("fingerprint":_) -> doFingerprint
       _ -> fail "unknown command (known commands: info show list-bin fingerprint)"
 
+main' :: IO ()
+main' = do
+    cmd <- execParser opts
+    case cmd of
+      InfoCommand -> doInfo
+  where
+    opts = subparser
+      (  command "info" (info infoOptions (progDesc "Info")) )
+
+commandParser :: Parser Command
+commandParser = pure InfoCommand
+
+data Command = InfoCommand
+  deriving (Show, Eq)
+  
 doListBin :: IO ()
 doListBin = do
     (v,_projbase) <- findAndDecodePlanJson

--- a/src-exe/cabal-plan.hs
+++ b/src-exe/cabal-plan.hs
@@ -32,8 +32,7 @@ main = do
     opts = info ((optParser <|> defaultParser) <**> helper)
       ( fullDesc )
     optParser = subparser
-      (  command "" (info (pure InfoCommand) (progDesc "Info"))
-      <> command "info" (info (pure InfoCommand) (progDesc "Info"))
+      (  command "info" (info (pure InfoCommand) (progDesc "Info"))
       <> command "show" (info (pure ShowCommand) (progDesc "Show"))
       <> command "list-bin" (info (pure ListBinCommand) (progDesc "List Binaries"))
       <> command "fingerprint" (info (pure FingerprintCommand) (progDesc "Fingerprint")))


### PR DESCRIPTION
I haven't used cabal in a while (intend to get back to it eventually), so I stubbed out each command to print out the name of the command and invoked each option to test this change. Each of the five possibilities worked as expected. I built with stack using lts-8.13.

I noted areas for improvement in the commit messages "Initial working .."

```
$ cabal-plan --help
Usage: cabal-plan [COMMAND]

Available options:
  -h,--help                Show this help text

Available commands:
  info                     Info
  show                     Show
  list-bin                 List Binaries
  fingerprint              Fingerprint
```

I am not familiar with cabal-plan or the plan.json file's purpose yet. I would be curious to learn more and possibly contribute more to this project specifically. If you created a short unit test suite (or if you express your preferences for libraries used in such a suite, I might get time to do that soon), that might facilitate others understanding the typical usages of this executable.

Stackage's selected dependency versions:
```
$ stack list-dependencies --depth 1
aeson 1.0.2.1
ansi-terminal 0.6.2.3
base 4.9.1.0
base16-bytestring 0.1.1.6
bytestring 0.10.8.1
cabal-plan 0.1.1.0
containers 0.5.7.1
directory 1.3.0.0
filepath 1.4.1.1
mtl 2.2.1
optparse-applicative 0.13.2.0
text 1.2.2.1
```